### PR TITLE
Added back the lib eager loading to prevent issues with Knock::Authen…

### DIFF
--- a/lib/knock/engine.rb
+++ b/lib/knock/engine.rb
@@ -2,6 +2,7 @@ require 'rails/engine'
 
 module Knock
   class Engine < ::Rails::Engine
+    paths.add 'lib', eager_load: true
     isolate_namespace Knock
   end
 end


### PR DESCRIPTION
Currently Knock::Authenticable does not get autoloaded when including on models. This PR reverts a previous commit that eager loads all knock lib models. 